### PR TITLE
Replace boost.math with own functions, prevent c++11 issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ include_directories(
 # set compilation defines
 add_definitions( ${CLAW_DEFINITIONS} )
 
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++03")
+
 #-------------------------------------------------------------------------------
 # application
 set( CLAW_APPLICATION_SOURCES

--- a/claw/code/tween/easing/easing_elastic.cpp
+++ b/claw/code/tween/easing/easing_elastic.cpp
@@ -28,7 +28,6 @@
  */
 #include <claw/tween/easing/easing_elastic.hpp>
 
-#include <boost/math/constants/constants.hpp>
 #include <cmath>
 
 /**
@@ -38,7 +37,7 @@
  */
 double claw::tween::easing_elastic_func( double t )
 {
-  const double pi( boost::math::constants::pi<double>() );
+  const double pi( 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899L );
   const double v(t-1);
   const double p(0.3);
 

--- a/claw/code/tween/easing/easing_sine.cpp
+++ b/claw/code/tween/easing/easing_sine.cpp
@@ -28,7 +28,6 @@
  */
 #include <claw/tween/easing/easing_sine.hpp>
 
-#include <boost/math/constants/constants.hpp>
 #include <cmath>
 
 /**
@@ -38,6 +37,6 @@
  */
 double claw::tween::easing_sine_func( double t )
 {
-  const double pi( boost::math::constants::pi<double>() );
+  const double pi( 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899L );
   return 1 - std::cos(t * pi / 2);
 } // easing_sine_func()

--- a/claw/impl/curve.tpp
+++ b/claw/impl/curve.tpp
@@ -26,8 +26,9 @@
  * \brief Implementation of claw::math::curve.
  * \author Julien Jorge
  */
-#include <boost/math/special_functions/cbrt.hpp>
-#include <boost/math/constants/constants.hpp>
+
+#include <cmath>
+#include <limits>
 
 /*----------------------------------------------------------------------------*/
 /**
@@ -516,10 +517,12 @@ claw::math::curve<C, Traits>::section::get_roots_degree_3
   else if ( delta > 0 )
     {
     result.push_back
-      ( boost::math::cbrt
-        ( (-q + std::sqrt(delta)) / 2.0 )
-        + boost::math::cbrt
-        ( (-q - std::sqrt(delta)) / 2.0 ) - b / (3.0 * a));
+      ( std::pow(
+        ( (-q + std::sqrt(delta)) / 2.0 ),
+        1.L/3.L)
+        + std::pow(
+        ( (-q - std::sqrt(delta)) / 2.0 ) - b / (3.0 * a),
+        1.L/3.L));
     }
   else
     for ( std::size_t i=0; i!=3; ++i )
@@ -527,7 +530,7 @@ claw::math::curve<C, Traits>::section::get_roots_degree_3
         ( 2.0 * std::sqrt( -p / 3.0 )
           * std::cos
           ( std::acos( std::sqrt(27.0 / (- p * p * p)) * - q / 2.0 ) / 3.0
-            + 2.0 * i * boost::math::constants::pi<double>() / 3.0 ) 
+            + 2.0 * i * 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899L / 3.0 ) 
           - b / (3.0 * a));
 
   return result;


### PR DESCRIPTION
Boost.Math now (boost 1.76) requires c++11,
but source code does not work with c++11,
so replacing Boost.Math with standard functions.

This also fixes the build with gcc11 as it now requires `<limits>` to be included in curve impl.