### PR TITLE
Make build reproducible, do not include build time in docs

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1007,7 +1007,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # page will contain the date and time when the page was generated. Setting
 # this to NO can help when comparing the output of multiple runs.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the


### PR DESCRIPTION
Allow reproducible builds[1] by not including the build time.

[1] https://en.wikipedia.org/wiki/Reproducible_builds